### PR TITLE
Fix "read only" error when playing a song after another finishes

### DIFF
--- a/ready-player.el
+++ b/ready-player.el
@@ -417,7 +417,8 @@ replacing the current Image mode buffer."
   "Get the process playback buffer."
   (let ((buffer (get-buffer-create "*play*")))
     (with-current-buffer buffer
-      (erase-buffer)
+      (let ((inhibit-read-only t))
+        (erase-buffer))
       (let ((inhibit-message t))
         ;; Silence noise of entering shell-mode.
         (shell-mode)))


### PR DESCRIPTION
After a song finishes, opening another file to try to play it shows a "Text is read only" error. This happens because the playback buffer is in shell mode, and shell-mode sets parts of the buffer to read only.

So when ready-player--playback-buffer clears the playback buffer before returning it, it needs to use inhibit-read-only.

Fixes #2.