### PR TITLE
Document playing all video as audio (audio stream only + repeat)

### DIFF
--- a/README.org
+++ b/README.org
@@ -183,6 +183,19 @@ If you'd like to use different utilities to play video and audio, you can use =r
           (ready-player-is-video-p "mpv")))
 #+end_src
 
+Ready player does not auto advance for non-audio files to prevent switching between video window and Emacs.
+To force headless audio playback and support repeat, for example to play music from video files, use the following settings:
+
+#+begin_src emacs-lisp :lexical no
+  ;; Mark all video files as audio
+  (setq ready-player-supported-audio (append ready-player-supported-audio ready-player-supported-video))
+  ;; Disable video files
+  (setq ready-player-supported-video nil)
+  ;; Disable window creation (with mpv)
+  (setq ready-player-open-playback-commands
+        '(("mpv" "--audio-display=no" "--video=no" "--input-ipc-server=<<socket>>")))
+#+end_src
+
 ** Buttons (macOS SF Symbols)
 
 If you have [[https://lmno.lol/alvaro/emacs-insert-and-render-sf-symbols][SF symbol rendering in Emacs]] on macOS, you can use enable usage in buttons by invoking =(ready-player-macos-use-sf-symbols)=


### PR DESCRIPTION
When the player is running headless, we should always handle the repeat feature because playing another files is not uncomfortable. This is useful when playing music from video files with:

```elisp
(setq
  ready-player-open-playback-commands
  '(("mpv" "--audio-display=no" "--video=no" "--input-ipc-server=<<socket>>")))
```