### PR TITLE
Change default value of ready-player-minor-mode-map-prefix

### DIFF
--- a/ready-player.el
+++ b/ready-player.el
@@ -176,7 +176,7 @@ Value must be set before invoking `ready-player-mode'."
   :type 'boolean
   :group 'ready-player)
 
-(defcustom ready-player-minor-mode-map-prefix "C-c m"
+(defcustom ready-player-minor-mode-map-prefix "C-c #"
   "The global bindings prefix used in `ready-player-minor-mode'.
 
 Be sure to set `ready-player-set-global-bindings' to non-nil to enable


### PR DESCRIPTION
The changes in #21 brought some nice flexibility for the key bindings.

However, the `ready-player-minor-mode-map-prefix` default value of `C-c m` doesn't follow Emacs [Key Binding Conventions](https://www.gnu.org/software/emacs/manual/html_node/elisp/Key-Binding-Conventions.html). Sequences consisting of `C-c` and a letter are reserved for users.

I appreciate that `ready-player-minor-mode-map-prefix` can be customized, but it's probably a good idea to change it to something which follows the convention. `C-c` followed by punctuation is allocated for minor modes.

I looked at other well-known minor mode keymaps to see what they used. Some notable examples:

  - Flycheck uses `C-c !`. (Mnemonic: Warnings.)
  - Outline uses `C-c @`. (Mnemonic: at, as in location. The prefix has navigation and structural editing commands.)

My suggestion is `C-c #`. As a mnemonic: it resembles a sharp note in music notation, for playing audio.
