### PR TITLE
Add a 'ready-player-metadata-compact' variable to remove empty lines

### DIFF
--- a/ready-player.el
+++ b/ready-player.el
@@ -5,8 +5,8 @@
 ;; Author: Alvaro Ramirez https://xenodium.com
 ;; Package-Requires: ((emacs "28.1"))
 ;; URL: https://github.com/xenodium/ready-player
-;; Version: 0.31.2
-(defconst ready-player--version "0.31.2")
+;; Version: 0.31.3
+(defconst ready-player--version "0.31.3")
 
 ;; This package is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
@@ -434,6 +434,11 @@ Default value attempts to reuse existing window."
 (defcustom ready-player-ask-for-project-sustainability t
   "Ask for project sustainability with a button."
   :type 'boolean
+  :group 'ready-player)
+
+(defcustom ready-player-metadata-separator "\n\n"
+  "Set the separator between metadata rows (default is '\n\n', i.e., one empty line)."
+  :type 'string
   :group 'ready-player)
 
 (defvar-local ready-player--process nil "Media-playing process.")
@@ -2397,7 +2402,7 @@ If SILENT, do not output any issues."
                                (propertize label 'face 'font-lock-comment-face)
                                (make-string (- max-label-length (length label)) ?\s)
                                value)))
-                   rows "\n\n"))
+                   rows ready-player-metadata-separator))
     ""))
 
 (defun ready-player--format-duration (duration)


### PR DESCRIPTION
This is just a new variable to allow removing empty lines in the metadata. This allows using a smaller frame for the buffer, particularly useful when I use Emacs on my phone (it has a qwerty-slider built-in which makes all my Emacs uses actually feasible on it) where screen real estate is precious, but I also prefer how it looks on desktop. Not everyone will agree, hence the variable.

`(setq ready-player-metadata-compact 'nil)` (default) _vs._ `(setq ready-player-metadata-compact t)`:

<img width="2160" height="1080" alt="ss20250825-000026" src="https://github.com/user-attachments/assets/296b5f3e-918d-4d8b-ae88-809f0dee1d7c" />
