### PR TITLE
fix(bookmark-filter): Ensure bookmark has valid file extension

### DIFF
--- a/ready-player.el
+++ b/ready-player.el
@@ -3320,7 +3320,10 @@ Source: File list fed to the metadata indexer"
   (seq-filter
    (lambda (bookmark)
      (or (equal (bookmark-prop-get bookmark 'bookmarked-by) 'ready-player)
-         (ready-player-is-supported-media-p (bookmark-prop-get bookmark 'filename))))
+         (when-let* ((filename (bookmark-prop-get bookmark 'filename)))
+           (and (file-regular-p filename)
+                (file-name-extension filename)
+                (ready-player-is-supported-media-p filename)))))
    bookmark-alist))
 
 ;;;###autoload


### PR DESCRIPTION
Filtering bookmarks now checks that the bookmark references a regular file with a file extension before verifying if it's a supported media type. This prevents errors when encountering bookmarks without filenames or those pointing to directories.

for example:

- `bookmark-set` save a dired buffer with a directory path as filename.

- `bufferlo` package use `bufferlo-bookmark-tab-save` to save a bookmark item which without filename property.